### PR TITLE
Add a null check

### DIFF
--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -84,7 +84,11 @@ public class Leech
                 AtomicReader ir = subreaders.pop();
 
                 Terms terms = ir.terms(this.field);
-                tenum = terms.iterator(null);
+                if (terms != null) {
+                		tenum = terms.iterator(null);
+                } else {
+                		return null;
+                }
             } else {
                 return null;
             }

--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -85,9 +85,9 @@ public class Leech
 
                 Terms terms = ir.terms(this.field);
                 if (terms != null) {
-                		tenum = terms.iterator(null);
+                    tenum = terms.iterator(null);
                 } else {
-                		return null;
+                    return null;
                 }
             } else {
                 return null;


### PR DESCRIPTION
This change adds a null check so that indexing by term that doesn't exist in the index doesn't cause a NullPointerException.
